### PR TITLE
Typo in Telephony Services (probably all language strings)

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -547,7 +547,7 @@
     <string name=" hide_error_from_network_text">Unable to Process Request</string>
 
     <string name="gsm_umts_options">GSM/UMTS Options</string>
-    <string name="call_forward_option">CallForward Options</string>
+    <string name="call_forward_option">Call Forward Options</string>
     <string name="cdma_options">CDMA Options</string>
 
     <!-- Screen option on the mobile network settings to go into data usage settings -->


### PR DESCRIPTION
There's a typo in the <string name="call_forward_option"> string. It reads: "CallForward Options", whilst it should read: "Call Forward Options". There's a missing space between the words "Call" & "Forward".

I suggest checking all the other languages as well, as "Kim Le" in LineageOS Jira Bug tracker mentioned that probably all other languages are affected as well (or might not even being translated at all). In this case the missing space between "Call" & "Forward" should be corrected in all other language pack/strings as well. I'm mentioning this, because I did not wanted to create 20+ pull requests for all other languages as well.

I would be happy to see them corrected in a upcoming LineageOS nightly/build.